### PR TITLE
Fix typos in transform-tokens workflow

### DIFF
--- a/.github/workflows/transform-tokens.yml
+++ b/.github/workflows/transform-tokens.yml
@@ -5,7 +5,7 @@ on:
   repository_dispatch:
     # and the event_type property from the request body is 'update-tokens'
     types: update-tokens
-# the following defines the jon that is run if the above is true
+# the following defines the job that is run if the above is true
 jobs:
   build:
     # the name for the entire job
@@ -36,7 +36,7 @@ jobs:
         with:
           # we use version 14.x of node
           node-version: 14.x
-      # We now run npm i to install all dependencies and run the "transfrom" script that is defined in the package.json (change this if you need to)
+      # We now run npm i to install all dependencies and run the "transform" script that is defined in the package.json (change this if you need to)
       - name: Transform design tokens 
         run: 'npm i && npm run transform-tokens'
       # We now store the changes in the repository


### PR DESCRIPTION
## Summary
- fix minor typos in transform-tokens workflow comments

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6846165822788326b4e9195e752845e9